### PR TITLE
Add support for loud comments

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ import postcss from 'postcss';
 const postcssFlexibility = postcss.plugin('postcss-flexibility', () => css => {
 	css.walkRules(rule => {
 		const isDisabled = rule.some(({prop, text}) =>
-			prop === '-js-display' || text === 'flexibility-disable'
+			prop === '-js-display' || text === 'flexibility-disable' || text === '! flexibility-disable'
 		);
 
 		if (!isDisabled) {


### PR DESCRIPTION
It is very important the add support for loud comments when working in production environments since normal comments are removed when compiling sass with as compressed.